### PR TITLE
feat: tsc 3: alias ImageTemplate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1236,9 +1236,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^6.0.52",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
-    "typescript": "~2.6.1"
+    "typescript": "~3.7.3"
   },
   "scripts": {
     "build": "tsc -p .",

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ export interface ImageTemplate {
     getRange(): Range | null;
 }
 
-export interface Dockerfile extends ImageTemplate {
+export interface Dockerfile extends ImageTemplateImpl {
 
     getEscapeCharacter(): string;
 
@@ -90,7 +90,7 @@ export interface Dockerfile extends ImageTemplate {
 
 import { Parser } from './parser';
 export { Flag } from './flag';
-import { ImageTemplate } from './imageTemplate';
+import { ImageTemplate as ImageTemplateImpl } from './imageTemplate';
 import { Instruction } from './instruction';
 export { Instruction };
 export { Line } from './line';


### PR DESCRIPTION
typescript 3 (including in client code) isn't happy with the duplicate use
of `ImageTemplate` as a `class` and as an `interface` here. I believe the intention
is to expose the interface, so maintain that behaviour, and instead alias
the class as we import it and extend it, and do not expose it.

Giving the two types different names, and exporting them, would probably be
clearer, but would be a breaking change?