### PR TITLE
fix: add support for single quote in JSONInstruction

### DIFF
--- a/src/jsonInstruction.ts
+++ b/src/jsonInstruction.ts
@@ -55,6 +55,7 @@ export class JSONInstruction extends ModifiableInstruction {
                         break argsCheck;
                     }
                     break;
+                case "'":
                 case '"':
                     if (last === '[' || last === ',') {
                         start = i;


### PR DESCRIPTION
Add support for this type of instructions `SHELL ['ls', '-l']`